### PR TITLE
Refactored MMR to Use Iteractors instead of Arrays

### DIFF
--- a/test/MerkleMountainRange.t.sol
+++ b/test/MerkleMountainRange.t.sol
@@ -136,11 +136,21 @@ contract MerkleMountainRangeTest is Test {
     }
 
     function mmrLeafToNode(
-        MmrLeaf[] memory leaves,
-        MerkleMountainRange.LeafIterator memory leafIter
+        MmrLeaf[] memory leaves
     ) public pure returns (Node[] memory, uint256[] memory) {
-        // Delegate to the updated mmrLeafToNode function in MerkleMountainRange
-        return MerkleMountainRange.mmrLeafToNode(leaves, leafIter);
+        uint256 length = leaves.length;
+
+        // Initialize the arrays for nodes and indices
+        Node[] memory nodes = new Node[](length);
+        uint256[] memory indices = new uint256[](length);
+
+        // Populate the arrays
+        for (uint256 i = 0; i < length; i++) {
+            nodes[i] = Node(leaves[i].k_index, leaves[i].hash);
+            indices[i] = leaves[i].k_index;
+        }
+
+        return (nodes, indices);
     }
 
     function CalculateRoot(

--- a/test/MerkleMountainRange.t.sol
+++ b/test/MerkleMountainRange.t.sol
@@ -102,7 +102,8 @@ contract MerkleMountainRangeTest is Test {
     function leavesForPeak(
         MmrLeaf[] memory leaves,
         uint64 peak
-    ) public pure returns (MmrLeaf[] memory, MmrLeaf[] memory) {
+    ) public pure returns (MerkleMountainRange.LeafIterator memory, MerkleMountainRange.LeafIterator memory) {
+        // Use the updated leavesForSubtree that returns iterators
         return MerkleMountainRange.leavesForSubtree(leaves, peak);
     }
 
@@ -120,9 +121,11 @@ contract MerkleMountainRangeTest is Test {
     }
 
     function mmrLeafToNode(
-        MmrLeaf[] memory leaves
+        MmrLeaf[] memory leaves,
+        MerkleMountainRange.LeafIterator memory leafIter
     ) public pure returns (Node[] memory, uint256[] memory) {
-        return MerkleMountainRange.mmrLeafToNode(leaves);
+        // Delegate to the updated mmrLeafToNode function in MerkleMountainRange
+        return MerkleMountainRange.mmrLeafToNode(leaves, leafIter);
     }
 
     function CalculateRoot(

--- a/test/MerkleMountainRange.t.sol
+++ b/test/MerkleMountainRange.t.sol
@@ -102,9 +102,24 @@ contract MerkleMountainRangeTest is Test {
     function leavesForPeak(
         MmrLeaf[] memory leaves,
         uint64 peak
-    ) public pure returns (MerkleMountainRange.LeafIterator memory, MerkleMountainRange.LeafIterator memory) {
-        // Use the updated leavesForSubtree that returns iterators
-        return MerkleMountainRange.leavesForSubtree(leaves, peak);
+    ) public pure returns (MmrLeaf[] memory, MmrLeaf[] memory) {
+        // Get the iterators for the left and right ranges
+        (MerkleMountainRange.LeafIterator memory leftIter, MerkleMountainRange.LeafIterator memory rightIter) =
+            MerkleMountainRange.leavesForSubtree(leaves, peak);
+
+        // Extract the leaves for the left range
+        MmrLeaf[] memory leftLeaves = new MmrLeaf[](leftIter.length);
+        for (uint256 i = 0; i < leftIter.length; i++) {
+            leftLeaves[i] = leaves[leftIter.offset + i];
+        }
+
+        // Extract the leaves for the right range
+        MmrLeaf[] memory rightLeaves = new MmrLeaf[](rightIter.length);
+        for (uint256 i = 0; i < rightIter.length; i++) {
+            rightLeaves[i] = leaves[rightIter.offset + i];
+        }
+
+        return (leftLeaves, rightLeaves);
     }
 
     function difference(


### PR DESCRIPTION
Refactored MMR to Use Iteractors instead of Arrays, I updated the current test suite to be compatible but havent added more tests so coverage will be lower. 
I added a struct LeafIterator for ease of use but it might look ugly in the tests since we end up calling it with MerkleMountainRange.LeafIterator, but again they are just tests so i guess its fine.