### PR TITLE
Reject merkle multiproofs with unconsumed leaves

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polytope-labs/solidity-merkle-trees",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The most advanced solidity library for merkle (multi) proof verification of different kinds of merkle trees",
   "author": "Polytope Labs <hello@polytope.technology>",
   "license": "Apache-2.0",

--- a/src/MerkleMultiProof.sol
+++ b/src/MerkleMultiProof.sol
@@ -41,6 +41,8 @@ library MerkleMultiProof {
     error LeafIndexOutOfBounds();
     // @dev Thrown when leaves are not strictly sorted by index (catches duplicates too).
     error UnsortedLeaves();
+    // @dev Thrown when leaves are unconsumed.
+    error UnconsumedLeaves(uint256 len);
 
     /**
      * @notice Verify a Merkle Multi Proof
@@ -168,6 +170,9 @@ library MerkleMultiProof {
             len = j;
             nodesAtLevel = (nodesAtLevel + 1) >> 1;
         }
+
+        // invariant: all leaves must have been consumed.
+        if (len != 1) revert UnconsumedLeaves(len);
 
         return hashes[0];
     }

--- a/tests/foundry/MerkleMultiProof.t.sol
+++ b/tests/foundry/MerkleMultiProof.t.sol
@@ -92,4 +92,70 @@ contract MerkleMultiProofTest is Test {
         vm.expectRevert(MerkleMultiProof.UnsortedLeaves.selector);
         this.CalculateRoot(proof, leaves, 4);
     }
+
+    /**
+     * @notice Critical forgery: `_walk` terminates at the genuine root, discarding the
+     *         forged leaf's partial subtree.
+     *
+     *         We manually build a genuine 4-leaf tree (leaves at positions 4..7):
+     *
+     *                       1 = root
+     *                     /   \
+     *                   2       3
+     *                  / \     / \
+     *                 4   5   6   7      n2 = H(a,b) at pos 2, n3 = H(c,d) at pos 3
+     *                 a   b   c   d      root = H(n2,n3) at pos 1
+     *
+     *         A leafCount above 2^255 makes `firstLeafPos = 1 << _ceilLog2(leafCount) =
+     *         1 << 256 = 0`, so leaf positions equal raw indices — freeing leaves from the
+     *         leaf level. (Exactly `type(uint256).max` would instead overflow `lastValid`
+     *         in `_walk` before it runs; any value in (2^255, ~2^256) reproduces the bug,
+     *         so we use 2^255 + 1.)
+     *
+     *         The attacker proves the genuine first leaf `a` at position 4 AND appends a
+     *         forged leaf at position 8 — a phantom child below position 4. `_walk` rebuilds
+     *         the genuine branch (4 -> 2 -> 1 = root) and the `while (positions[0] != 1)`
+     *         loop exits the instant it reaches the root, while the forged leaf's partial
+     *         climb (8 -> 4 -> 2) is still in the set (`len == 2`). The old code returned
+     *         `hashes[0]` (= the genuine root), so the forged leaf "verified" against it.
+     *         Must now revert UnconsumedLeaves.
+     */
+    function testForgery_TerminateAtRoot_UnconsumedForgedSubtree() public {
+        // Genuine 4-leaf tree, hashed per `_hashPair` (even position => keccak(current, sibling)).
+        bytes32 a = keccak256("a");
+        bytes32 b = keccak256("b");
+        bytes32 c = keccak256("c");
+        bytes32 d = keccak256("d");
+        bytes32 n2 = keccak256(abi.encodePacked(a, b)); // position 2
+        bytes32 n3 = keccak256(abi.encodePacked(c, d)); // position 3
+        bytes32 root = keccak256(abi.encodePacked(n2, n3)); // position 1
+
+        uint256 leafCount = (uint256(1) << 255) + 1; // => firstLeafPos = (1 << 256) = 0
+
+        // Sanity: the honest proof of leaf `a` (position 4) rebuilds the genuine root.
+        {
+            MerkleMultiProof.Leaf[] memory genuine = new MerkleMultiProof.Leaf[](1);
+            genuine[0] = MerkleMultiProof.Leaf(4, a);
+            bytes32[] memory genuineProof = new bytes32[](2);
+            genuineProof[0] = b; // sibling at position 5
+            genuineProof[1] = n3; // uncle at position 3
+            assertTrue(MerkleMultiProof.VerifyProof(root, genuineProof, genuine, leafCount));
+        }
+
+        // Forgery: genuine leaf at position 4 + forged leaf at position 8.
+        MerkleMultiProof.Leaf[] memory leaves = new MerkleMultiProof.Leaf[](2);
+        leaves[0] = MerkleMultiProof.Leaf(4, a); // genuine, position 4
+        leaves[1] = MerkleMultiProof.Leaf(8, keccak256("forged")); // forged, position 8
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = b; // genuine: pos 4 sibling -> n2
+        proof[1] = keccak256("forged-sibling"); // forged climb (discarded by old code)
+        proof[2] = n3; // genuine: pos 2 sibling -> root
+        proof[3] = keccak256("forged-uncle"); // forged climb (discarded by old code)
+
+        // Old behaviour: returned hashes[0] (= genuine root), forged subtree silently dropped.
+        // Fixed behaviour: walk ends with len == 2, so it reverts.
+        vm.expectRevert(abi.encodeWithSelector(MerkleMultiProof.UnconsumedLeaves.selector, uint256(2)));
+        this.CalculateRoot(proof, leaves, leafCount);
+    }
 }


### PR DESCRIPTION
## Summary

Closes a critical proof-forgery vulnerability in `MerkleMultiProof`: `_walk` returned `hashes[0]` as soon as `positions[0]` reached the root (position 1), **without checking that all leaves were consumed**. An attacker could prove a forged leaf against a genuine root by appending it to a real proof.

### The attack

With `leafCount > 2^255`, `firstLeafPos = 1 << _ceilLog2(leafCount) = 1 << 256 = 0`, so leaf positions equal raw indices — freeing leaves from the leaf level. An attacker proves a genuine leaf (e.g. position 4 of a real tree) and appends a forged leaf at a deeper phantom position (e.g. 8). `_walk` rebuilds the genuine branch `4 → 2 → 1 = root` and the loop exits the moment `positions[0]` hits the root, while the forged leaf's partial climb (`8 → 4 → 2`) is left unconsumed (`len == 2`). The old code returned the genuine root anyway, so the forged leaf "verified".

### Fix

After the walk, assert the invariant that all leaves were consumed:

```solidity
if (len != 1) revert UnconsumedLeaves(len);
```

## Test

`testForgery_TerminateAtRoot_UnconsumedForgedSubtree` manually builds a genuine 4-leaf tree, confirms the honest single-leaf proof rebuilds the root, then runs the forgery (genuine leaf at position 4 + forged leaf at position 8) and asserts it now reverts `UnconsumedLeaves(2)`. Verified as a real regression guard: with the `len != 1` check removed, the test fails because `CalculateRoot` returns the genuine root.

## Version

`@polytope-labs/solidity-merkle-trees` bumped `1.0.0` → `1.1.0`.
